### PR TITLE
[NY-9223] Promotion happens after dev version publishes [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit
-  test-pack:
+  publish-dev-and-promote:
     jobs:
       - orb-tools/lint # Lint Yaml files
       - orb-tools/pack # Pack orb source
@@ -20,21 +20,14 @@ workflows:
           requires:
             - orb-tools/lint
             - orb-tools/pack
-
-  deploy:
-    jobs:
-      # Publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major|skip]"
-      # as that will determine whether a patch, minor or major
-      # version will be published or if publishing should
-      # be skipped.
-      # e.g. [semver:patch] will cause a patch version to be published.
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: noyo/gcp-npm
           context: orb-publishing
           add-pr-comment: false
           fail-if-semver-not-indicated: true
           publish-version-tag: false
+          requires:
+            - orb-tools/publish-dev
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description

Prod promotion depends on a dev version, with the commit hash existing. The problem was that CI was organized as two different workflows, so one did not depends on the other. Reorganizing so they happen in series, and the dev version will be published, then promoted to production.

```
Error: Cannot find orb dev version with version dev:0cb9b9f
```

Ticket: https://noyotechnologies.atlassian.net/browse/NY-9223